### PR TITLE
Faster way to reach profile page

### DIFF
--- a/followers.py
+++ b/followers.py
@@ -16,11 +16,9 @@ class InstaUnfollowers:
         submit = self.driver.find_element_by_xpath('/html/body/div[1]/section/main/article/div[2]/div[1]/div/form/div/div[3]/button')
         submit.click()
         sleep(3)
-        ad = self.driver.find_element_by_xpath("//button[contains(text(), 'Not Now')]")
-        ad.click()
+        self.driver.find_element_by_xpath('/html/body/div[1]/section/nav/div[2]/div/div/div[3]/div/div[5]/span/img').click()        
+        self.driver.find_element_by_xpath('/html/body/div[1]/section/nav/div[2]/div/div/div[3]/div/div[5]/div[2]/div[2]/div[2]/a[1]/div/div[2]/div/div/div/div').click()
         sleep(3)
-        ad = self.driver.find_element_by_xpath("//button[contains(text(), 'Not Now')]")
-        ad.click()
 
     def get_unfollowers(self):
         usernames = self.driver.find_element_by_xpath("/html/body/div[1]/section/nav/div[2]/div/div/div[3]/div/div[5]/span/img")


### PR DESCRIPTION
Tackling the pop-up just after logging into Instagram is usually error-prone and inefficient. The changes will allow the user to directly go to their profile page without having to select the 'Not Now' button.